### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Initializes a new instance of the CsvMatch class.
 </ul>
 <br/>
 
-**`validate(self, value, metadata) → ValidationResult`**
+**`validate(self, value, metadata) -> ValidationResult`**
 <ul>
 Validates the given `value` using the rules defined in this validator, relying on the `metadata` provided to customize the validation process. This method is automatically invoked by `guard.parse(...)`, ensuring the validation logic is applied to the input data.
 


### PR DESCRIPTION
Fix UnicodeEncodeError for the character '\u2192' in the 'guardrails hub install' console output.

Resolved an issue where the Unicode character '\u2192' (right arrow) caused a UnicodeEncodeError during guardrails installations on Windows, Linux, macOS